### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# codeowners that will be tagged for review for any pull request opened
+* @cayd @j100892


### PR DESCRIPTION
closes #100

I've enabled branch protection on the main branch, which should now require PR approval before merging. 

Adding this file here is a way to automate tagging certain people for review when a PR is opened. 
Please do suggest others that might be good to have

here's more about [the github CODEOWNERS file](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)

