### PR TITLE
convert Button to MaterialUI Button

### DIFF
--- a/react/client/src/App.tsx
+++ b/react/client/src/App.tsx
@@ -24,7 +24,7 @@ import 'styles/App.css';
 const theme = createMuiTheme({
   palette: {
     primary: {
-      main: purple[500],
+      main: '#9903FF',
     },
     secondary: {
       main: '#0AEBA0',

--- a/react/client/src/components/Button.tsx
+++ b/react/client/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Theme, makeStyles, createStyles } from '@material-ui/core';
+import { Button, Theme, makeStyles, createStyles } from '@material-ui/core';
 
 import arrowRight from '../assets/arrowRight.svg';
 
@@ -34,7 +34,7 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
 
       boxShadow: (props) => {
         switch (props.theme) {
-          case 'white':
+          case 'transparent':
             return 'none';
           default:
             return `4px 4px 16px rgba(61, 0, 102, 0.25)`;
@@ -43,8 +43,8 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
 
       color: (props) => {
         switch (props.theme) {
-          case 'white':
-            return 'black';
+          case 'transparent':
+            return '#25003F, 100%';
           default:
             return '#FFFFFF';
         }
@@ -54,7 +54,7 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
         switch (props.theme) {
           case 'dark':
             return '#25003F';
-          case 'white':
+          case 'transparent':
             return 'white';
           default:
             return '#9903FF';
@@ -65,7 +65,7 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
           switch (props.theme) {
             case 'dark':
               return '#330652';
-            case 'white':
+            case 'transparent':
               return 'white';
             default:
               return '#a224f7';
@@ -80,15 +80,20 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
   })
 );
 
-const Button = ({ theme, hasArrow, buttonText, onClick }: ComponentProps) => {
+const ButtonComponent = ({
+  theme,
+  hasArrow,
+  buttonText,
+  onClick,
+}: ComponentProps) => {
   const styleProps = { theme, hasArrow };
   const classes = useStyles(styleProps);
   return (
-    <button type="button" className={classes.root} onClick={onClick}>
+    <Button type="button" className={classes.root} onClick={onClick}>
       {buttonText}
       {hasArrow && <img src={arrowRight} alt="arrow right" />}
-    </button>
+    </Button>
   );
 };
 
-export default Button;
+export default ButtonComponent;


### PR DESCRIPTION
Fixes issue #171 

Converted Button component to MaterialUI Button
-Added switch statements for Button `props.theme` to change theme of button. Now we have 3 themes - transparent, dark, default

I had actually made most of these changes before in #163 before I read this Issue, but now this one is a little different (named the transparent theme "transparent" instead of "white") so let me know what the best way would be to merge both of these PRs

Notes: The focus state (opaque animation) is built in to MaterialUI's Button. But if you want an active click state - I couldn't find an example in the figma? Maybe we can discuss in the meeting.


https://user-images.githubusercontent.com/35116846/109598402-1b9c1e80-7ace-11eb-82ec-22e181fa35fb.mov

